### PR TITLE
Use an array of 100 random strings

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,17 +1,7 @@
 <script lang="ts" setup>
-const items = [
-    'a',
-    'a',
-    'a',
-    'a',
-    'a',
-    'a',
-    'a',
-    'a',
-    'a',
-    'a',
-    'abc'
-]
+const items = Array.from({ length: 100 }, () =>
+  Math.random().toString(36).substring(7)
+);
 </script>
 <template>
   <v-app>


### PR DESCRIPTION
With an array of random strings, cypress is crashing or throwing an error more consistently.